### PR TITLE
Fix reinstall brick

### DIFF
--- a/installer/src/main.c
+++ b/installer/src/main.c
@@ -24,8 +24,6 @@
 #define ARRAYSIZE(x) ((sizeof(x)/sizeof(0[x])) / ((size_t)(!(sizeof(x) % sizeof(0[x])))))
 
 int _vshSblAimgrGetConsoleId(char cid[32]);
-int sceKernelPowerLock(int x);
-int sceKernelPowerUnlock(int x);
 int sceSblSsUpdateMgrSetBootMode(int x);
 int vshPowerRequestColdReset(void);
 


### PR DESCRIPTION
Don't run this unless you can recover from a brick.

Situation: user installs enso, then reinstalls 3.60 (which uninstalls enso but not the backup MBR), then runs enso app and selects uninstall. Result: brick.

This fixes it by always overwriting block 0 with a copy of block 0 which when enso is installed would redirect the reads to block 1 but not writes, and when enso is not installed would not do anything.

Tests:
- [x] Without the patch: Install enso, reboot, uninstall enso
- [x] Without the patch: Install enso, flash 3.60, **make nand backup !!**, uninstall enso; confirm this bricks
- [x] With the patch: Install enso, flash 3.60, **make nand backup !!**, uninstall enso; confirm this does not brick anymore
- [x] With the patch: Install enso, reboot, uninstall enso
- [x] With the patch: Install enso, reboot, uninstall enso, reboot, uninstall enso
- Run all tests from the old google forms

make a nand backup every time you reflash 3.60!